### PR TITLE
Support using Docker for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,30 @@ Compile the translation files:
 python manage.py compilemessages
 ```
 
+#### Docker
+
+You can also use Docker in development. Start server in `http://localhost:8000` by running:
+
+```shell
+docker-compose up
+```
+
+To run Django commands:
+
+```shell
+docker-compose run app python manage.py <command>
+```
+
 ### Production
 
 The project is containerized using Docker Compose. You will still need to set some
 variables in your environment; see the first few lines in `aplans/settings.py`.
+
+Use this command to apply the production configuration `docker-compose.production.yml`:
+
+```shell
+docker-compose -f docker-compose.yml -f docker-compose.production.yml up
+```
 
 ## Contributing
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+# Development configuration file
+#
+# This file is automatically merged with docker-compose.yml
+# when 'docker-compose up' is run.
+
+version: '3.2'
+services:
+  app:
+    volumes:
+      - .:/code
+    environment:
+      - DATABASE_URL=postgres://aplans@db/aplans

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,15 @@
+# Production configuration file
+#
+# To apply this configuration, run:
+# docker-compose -f docker-compose.yml -f docker-compose.production.yml up
+
+version: '3.2'
+services:
+  db:
+    restart: always
+
+  app:
+    build:
+      cache_from:
+        - ${DOCKER_CACHE_IMAGE:-aplans_app}
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build:
       context: .
       dockerfile: ./docker/db/Dockerfile
-    restart: always
     environment:
       - POSTGRES_USER=aplans
     volumes:
@@ -16,9 +15,6 @@ services:
     build:
       context: .
       dockerfile: docker/app/Dockerfile
-      cache_from:
-        - ${DOCKER_CACHE_IMAGE:-aplans_app}
-    restart: always
     volumes:
       - aplans_media:/srv/media
     environment:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -36,4 +36,4 @@ RUN ./manage.py compilemessages
 COPY ./docker/app/docker-entrypoint.sh /
 COPY ./docker/app/wait-for-it.sh /
 
-ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]
+CMD ["/bin/bash", "/docker-entrypoint.sh"]


### PR DESCRIPTION
**This is a breaking change for production!**

Docker Compose must be run in this way in production:
```shell
docker-compose -f docker-compose.yml -f docker-compose.production.yml up
```
Docker compose files:

File | Purpose
--- | ---
`docker-compose.yml` | Base file
`docker-compose.override.yml` | Override file to use in development, used by default when running `docker-compose up`
`docker-compose.production.yml` | Override file to use in production, not using `docker-compose.override.yml`

See:
* https://docs.docker.com/compose/production/
* https://docs.docker.com/compose/extends/